### PR TITLE
Add callback with time span to all time functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
+* Add support for callback functionality on timing functions.
+
 0.14.1
 ======
 

--- a/lib/graphite_async.ml
+++ b/lib/graphite_async.ml
@@ -223,10 +223,7 @@ module Result = struct
     let timer = timer_ms () in
     let%bind r = f v in
     let time_span = timer () in
-    let () = match callback with
-      | Some callback -> callback time_span v r
-      | None -> ()
-    in
+    Core.Option.iter callback ~f:(fun callback -> callback time_span v r);
     let sub_key =
       match r with
       | Ok _ -> "ok"
@@ -244,10 +241,7 @@ module Option = struct
     let timer = timer_ms () in
     let%bind r = f v in
     let time_span = timer () in
-    let () = match callback with
-      | Some callback -> callback time_span v r
-      | None -> ()
-    in
+    Core.Option.iter callback ~f:(fun callback -> callback time_span v r);
     let sub_key =
       match r with
       | Some _ -> "ok"
@@ -265,10 +259,7 @@ module Deferred = struct
     let timer = timer_ms () in
     let%bind r = f v in
     let time_span = timer () in
-    let () = match callback with
-      | Some callback -> callback time_span v r
-      | None -> ()
-    in
+    Core.Option.iter callback ~f:(fun callback -> callback time_span v r);
     add_percentile_observation_opt
       graphite
       ~key:(Printf.sprintf "%s.ok" key)
@@ -279,10 +270,7 @@ module Deferred = struct
     let timer = timer_ms () in
     let%bind chunk, r = f v in
     let time_span = timer () in
-    let () = match callback with
-      | Some callback -> callback time_span v (chunk, r)
-      | None -> ()
-    in
+    Core.Option.iter callback ~f:(fun callback -> callback time_span v (chunk, r));
     add_percentile_observation_opt
       graphite
       ~key:(Printf.sprintf "%s.%s" key chunk)

--- a/lib/graphite_async.ml
+++ b/lib/graphite_async.ml
@@ -8,7 +8,7 @@ let timer_ms () =
   let start_ts = Time.now () in
   fun () ->
     let end_ts = Time.now () in
-    Time.diff end_ts start_ts |> Time.Span.to_ms |> int_of_float
+    Time.diff end_ts start_ts
 
 module Percentile = struct
   type ts = int
@@ -219,9 +219,14 @@ let add_percentile_observation_opt t ~key value =
   | Some t -> add_percentile_observation t ~key value
 
 module Result = struct
-  let time ?graphite ~key ~f v =
+  let time ?graphite ?callback ~key ~f v =
     let timer = timer_ms () in
     let%bind r = f v in
+    let time_span = timer () in
+    let () = match callback with
+      | Some callback -> callback time_span v r
+      | None -> ()
+    in
     let sub_key =
       match r with
       | Ok _ -> "ok"
@@ -230,14 +235,19 @@ module Result = struct
     add_percentile_observation_opt
       graphite
       ~key:(Printf.sprintf "%s.%s" key sub_key)
-      (timer ());
+      (time_span |> Time.Span.to_ms |> int_of_float);
     return r
 end
 
 module Option = struct
-  let time ?graphite ~key ~f v =
+  let time ?graphite ?callback ~key ~f v =
     let timer = timer_ms () in
     let%bind r = f v in
+    let time_span = timer () in
+    let () = match callback with
+      | Some callback -> callback time_span v r
+      | None -> ()
+    in
     let sub_key =
       match r with
       | Some _ -> "ok"
@@ -246,23 +256,36 @@ module Option = struct
     add_percentile_observation_opt
       graphite
       ~key:(Printf.sprintf "%s.%s" key sub_key)
-      (timer ());
+      (time_span |> Time.Span.to_ms |> int_of_float);
     return r
 end
 
 module Deferred = struct
-  let time ?graphite ~key ~f v =
+  let time ?graphite ?callback ~key ~f v =
     let timer = timer_ms () in
     let%bind r = f v in
-    add_percentile_observation_opt graphite ~key:(Printf.sprintf "%s.ok" key) (timer ());
+    let time_span = timer () in
+    let () = match callback with
+      | Some callback -> callback time_span v r
+      | None -> ()
+    in
+    add_percentile_observation_opt
+      graphite
+      ~key:(Printf.sprintf "%s.ok" key)
+      (time_span |> Time.Span.to_ms |> int_of_float);
     return r
 
-  let keyed_time ?graphite ~key ~f v =
+  let keyed_time ?graphite ?callback ~key ~f v =
     let timer = timer_ms () in
     let%bind chunk, r = f v in
+    let time_span = timer () in
+    let () = match callback with
+      | Some callback -> callback time_span v (chunk, r)
+      | None -> ()
+    in
     add_percentile_observation_opt
       graphite
       ~key:(Printf.sprintf "%s.%s" key chunk)
-      (timer ());
+      (time_span |> Time.Span.to_ms |> int_of_float);
     return r
 end

--- a/lib/graphite_async.mli
+++ b/lib/graphite_async.mli
@@ -55,8 +55,8 @@ val report : t -> Report.t
 val flush : t -> unit Deferred.t
 
 module Result : sig
-  val time :
-    ?graphite:t ->
+  val time
+    :  ?graphite:t ->
     ?callback:(Time.Span.t -> 'a -> ('b, 'c) Result.t -> unit) ->
     key:string ->
     f:('a -> ('b, 'c) Deferred.Result.t) ->
@@ -65,8 +65,8 @@ module Result : sig
 end
 
 module Option : sig
-  val time :
-    ?graphite:t ->
+  val time
+    :  ?graphite:t ->
     ?callback:(Time.Span.t -> 'a -> 'b option -> unit) ->
     key:string ->
     f:('a -> 'b option Deferred.t) ->
@@ -75,16 +75,16 @@ module Option : sig
 end
 
 module Deferred : sig
-  val time :
-    ?graphite:t ->
+  val time
+    :  ?graphite:t ->
     ?callback:(Time.Span.t -> 'a -> 'b -> unit) ->
     key:string ->
     f:('a -> 'b Deferred.t) ->
     'a ->
     'b Deferred.t
 
-  val keyed_time :
-    ?graphite:t ->
+  val keyed_time
+    :  ?graphite:t ->
     ?callback:(Time.Span.t -> 'a -> string * 'b -> unit) ->
     key:string ->
     f:('a -> (string * 'b) Deferred.t) ->

--- a/lib/graphite_async.mli
+++ b/lib/graphite_async.mli
@@ -55,8 +55,9 @@ val report : t -> Report.t
 val flush : t -> unit Deferred.t
 
 module Result : sig
-  val time
-    :  ?graphite:t ->
+  val time :
+    ?graphite:t ->
+    ?callback:(Time.Span.t -> 'a -> ('b, 'c) Result.t -> unit) ->
     key:string ->
     f:('a -> ('b, 'c) Deferred.Result.t) ->
     'a ->
@@ -64,8 +65,9 @@ module Result : sig
 end
 
 module Option : sig
-  val time
-    :  ?graphite:t ->
+  val time :
+    ?graphite:t ->
+    ?callback:(Time.Span.t -> 'a -> 'b option -> unit) ->
     key:string ->
     f:('a -> 'b option Deferred.t) ->
     'a ->
@@ -73,10 +75,17 @@ module Option : sig
 end
 
 module Deferred : sig
-  val time : ?graphite:t -> key:string -> f:('a -> 'b Deferred.t) -> 'a -> 'b Deferred.t
+  val time :
+    ?graphite:t ->
+    ?callback:(Time.Span.t -> 'a -> 'b -> unit) ->
+    key:string ->
+    f:('a -> 'b Deferred.t) ->
+    'a ->
+    'b Deferred.t
 
-  val keyed_time
-    :  ?graphite:t ->
+  val keyed_time :
+    ?graphite:t ->
+    ?callback:(Time.Span.t -> 'a -> string * 'b -> unit) ->
     key:string ->
     f:('a -> (string * 'b) Deferred.t) ->
     'a ->


### PR DESCRIPTION
Can be used to log timing anomalies, like timings that take much longer
than the norm.