### PR TITLE
Remove optional graphite parameters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
+* Remove optional Graphite.t parameters
+
 0.14.3
 ======
 

--- a/lib/graphite_async.mli
+++ b/lib/graphite_async.mli
@@ -44,17 +44,11 @@ val incr : ?by:int -> key:string -> t -> unit
 
 val decr : t -> key:string -> int -> unit
 
-val incr_opt : ?by:int -> key:string -> t Option.t -> unit
-
-val decr_opt : t Option.t -> key:string -> int -> unit
-
 val set : t -> key:string -> int -> unit
 
 val remove : t -> key:string -> unit
 
 val add_percentile_observation : t -> key:string -> Percentile.value -> unit
-
-val add_percentile_observation_opt : t option -> key:string -> Percentile.value -> unit
 
 val report : t -> Report.t
 
@@ -62,7 +56,7 @@ val flush : t -> unit Deferred.t
 
 module Result : sig
   val time
-    :  ?graphite:t ->
+    :  graphite:t ->
     ?callback:(Time.Span.t -> 'a -> ('b, 'c) Result.t -> unit) ->
     key:string ->
     f:('a -> ('b, 'c) Deferred.Result.t) ->
@@ -72,7 +66,7 @@ end
 
 module Option : sig
   val time
-    :  ?graphite:t ->
+    :  graphite:t ->
     ?callback:(Time.Span.t -> 'a -> 'b option -> unit) ->
     key:string ->
     f:('a -> 'b option Deferred.t) ->
@@ -82,7 +76,7 @@ end
 
 module Deferred : sig
   val time
-    :  ?graphite:t ->
+    :  graphite:t ->
     ?callback:(Time.Span.t -> 'a -> 'b -> unit) ->
     key:string ->
     f:('a -> 'b Deferred.t) ->
@@ -90,7 +84,7 @@ module Deferred : sig
     'b Deferred.t
 
   val keyed_time
-    :  ?graphite:t ->
+    :  graphite:t ->
     ?callback:(Time.Span.t -> 'a -> string * 'b -> unit) ->
     key:string ->
     f:('a -> (string * 'b) Deferred.t) ->


### PR DESCRIPTION
This has always been confusing and error prone. Now that we have a mock `Graphite.t` there should be no need for having it optional anymore (Not sure there ever was a "need")

This is going to be released as part of a major version (1.0.0 ?)